### PR TITLE
simplified and improved stability of network widget

### DIFF
--- a/network.jsx
+++ b/network.jsx
@@ -2,15 +2,20 @@ const command = "bash pecan/scripts/network";
 const refreshFrequency = 5000; // ms
 
 const render = ({ output, error }) => {
+    let msg;
     if (error) {
-        return (<div>{String(error)}</div>)
+        msg = String(error);
+    } else if (output.length === 0) {
+        msg = 'Loading...';
+    } else {
+        const up_down = output.match(/\d*\.\d*/g);
+        msg = '↓ ' + up_down[0] + ' ↑ ' + up_down[1];
     }
 
-    const up_down = output.match(/\d*\.\d*/g);
     return (
         <div class='screen'>
             <div class='pecannetwork'>
-                ↓ {up_down[0]} ↑ {up_down[1]}
+                {msg}
             </div>
         </div>
     );

--- a/network.jsx
+++ b/network.jsx
@@ -9,7 +9,7 @@ const render = ({ output, error }) => {
         msg = 'Loading...';
     } else {
         const up_down = output.match(/\d*\.\d*/g);
-        msg = '↓ ' + up_down[0] + ' ↑ ' + up_down[1];
+        msg = '↓ ' + format_bandwidth(up_down[0]) + ' ↑ ' + format_bandwidth(up_down[1]);
     }
 
     return (
@@ -20,5 +20,9 @@ const render = ({ output, error }) => {
         </div>
     );
 };
+
+const format_bandwidth = (bandwidth) => {
+    return Math.round((bandwidth / 125)*100)/100 + ' Mbps'
+}
 
 export { command, refreshFrequency, render };

--- a/network.jsx
+++ b/network.jsx
@@ -1,6 +1,19 @@
 const command = "bash pecan/scripts/network";
 const refreshFrequency = 5000; // ms
 
-const render = ({ output }) => <div class='screen'><div class='pecannetwork'>{`${output}`}</div></div>;
+const render = ({ output, error }) => {
+    if (error) {
+        return (<div>{String(error)}</div>)
+    }
+
+    const up_down = output.match(/\d*\.\d*/g);
+    return (
+        <div class='screen'>
+            <div class='pecannetwork'>
+                ↓ {up_down[0]} ↑ {up_down[1]}
+            </div>
+        </div>
+    );
+};
 
 export { command, refreshFrequency, render };

--- a/scripts/down
+++ b/scripts/down
@@ -1,4 +1,0 @@
-#!/bin/bash
-# depends on ifstat
-
-/usr/local/bin/ifstat -n -z -S 1 1 | awk 'FNR == 3 {print $2}'

--- a/scripts/network
+++ b/scripts/network
@@ -5,7 +5,7 @@ exists () {
 }
 
 if exists /usr/local/bin/ifstat ; then
-	echo "↓ $(bash $(dirname "$0")/down) ↑ $(bash $(dirname "$0")/up)"
+    echo "$(/usr/local/bin/ifstat -n -z -S -i en0 1 1)"
 else
 	echo "↓ $(networksetup -getairportnetwork en0 | cut -c 24-)"
 fi

--- a/scripts/up
+++ b/scripts/up
@@ -1,4 +1,0 @@
-#!/bin/bash
-# depends on ifstat
-
-/usr/local/bin/ifstat -n -z -S 1 1 | awk 'FNR == 3 {print $3}'


### PR DESCRIPTION
I was looking at targeting a specific network interface and noticed awk supports `-i` to name the interfaces you want listed. Doing so started causing issues with how awk would parse the string into segments, for example if the up/down values were something like `   45.34  2430.23`, $1 would be ' ' instead of '45.34' because of the three spaces in front of the '45.34'. If up/down values were similar this issue didn't occur as the spacing from `ifstat` wasn't different between the two values. 

There may have been a way to make awk handle that situation better but I'm not familiar enough with it to work it out. Considering I wanted to do some unit conversion any way I opted for a regular expression in the jsx component instead. 

This could be further extended to listen to multiple interfaces and cumulate the bandwidth values across all of them (I find my mac uses wifi sometimes even when it's connected to ethernet).