### PR TITLE
config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ If Übersicht is running, then the bar should appear.
 
 This is a picture of my current config with all optional features enabled.
 
-To edit the appearance you can place a config at `~/.config/pecan.css` – the included `config.css` can be placed there to discover options.
+To edit the appearance you can place a config at `~/.config/pecan/pecan.css` – the included `config.css` can be placed there to discover options.
 
 ```sh
-mv "$HOME/Library/Application Support/Übersicht/widgets/pecan/config.css" "${HOME}/.config/pecan.css"
+mkdir -p "$HOME/.config/pecan" && mv "$HOME/Library/Application Support/Übersicht/widgets/pecan/config.css" "$HOME/.config/pecan/pecan.css"
 ```
 
 ## Optional features

--- a/scripts/network
+++ b/scripts/network
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-[[ -f "${HOME}/.config/pecan.css" ]] && [[ ! -f "$PWD/pecan/pecan.css" ]] && ln -s "${HOME}/.config/pecan.css" "${PWD}/pecan/pecan.css" && osascript -e "tell application id \"tracesOf.Uebersicht\" to refresh"
+[[ -f "${HOME}/.config/pecan/pecan.css" ]] && [[ ! -f "$PWD/pecan/pecan.css" ]] && ln -s "${HOME}/.config/pecan/pecan.css" "${PWD}/pecan/pecan.css" && osascript -e "tell application id \"tracesOf.Uebersicht\" to refresh"
 [[ -f "${HOME}/.cache/wal/colors.css" ]] && [[ ! -f "$PWD/pecan/colors.css" ]] && ln -s "${HOME}/.cache/wal/colors.css" "${PWD}/pecan/colors.css" && osascript -e "tell application id \"tracesOf.Uebersicht\" to refresh"
 
 exists () {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
 @import url(colors.css);
 
 /* import config */
-/* place the included config.css at ~/.config/pecan.css to make your own */
+/* place the included config.css at ~/.config/pecan/pecan.css to make your own */
 @import url(pecan.css);
 
 :root {


### PR DESCRIPTION
Hello! I noticed the default config location seems to be ~/.config/pecan.css. In my experience generally configs tend to be in ~/.config/{NAME}/{NAME}.{filetype}. I forked your repo and edited the config locations to match ~/.config/pecan/pecan.css (which includes instructions for making the ~/.config/pecan directory in the README); I thought I'd put up this pull request just to let you know. Of course everybody has a different workflow so I understand if you don't want to merge, this way just works better for me.