### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This can be done via the terminal like so:
 
 ```sh
 brew tap caskroom/cask
-brew cask install ubersicht
+brew install --cask ubersicht
 git clone https://github.com/zzzeyez/pecan.git "$HOME/Library/Application Support/Übersicht/widgets/pecan"
 ```
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524